### PR TITLE
Improve help message structure and consistency

### DIFF
--- a/recent_state_summarizer/__main__.py
+++ b/recent_state_summarizer/__main__.py
@@ -19,12 +19,6 @@ def build_parser():
 
     Retrieve the titles of articles from a specified URL.
     After summarization, prints the summary.
-
-    Support:
-        - はてなブログ（Hatena blog）
-        - はてなブックマークRSS
-        - Adventar
-        - Qiita Advent Calendar
     """
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -32,12 +26,31 @@ def build_parser():
     )
     subparsers = parser.add_subparsers(dest="subcommand")
 
-    run_parser = subparsers.add_parser("run", help=argparse.SUPPRESS)
+    run_parser = subparsers.add_parser(
+        "run", help="Fetch article titles and generate summary (default)"
+    )
     run_parser.add_argument("url", help="URL of archive page")
     run_parser.set_defaults(func=run_cli)
 
+    fetch_help_message = """
+    Retrieve the titles and URLs of articles from a web page specified by URL
+    and save them as JSON Lines format.
+
+    Support:
+        - はてなブログ（Hatena blog）
+        - はてなブックマークRSS
+        - Adventar
+        - Qiita Advent Calendar
+
+    Example:
+        omae-douyo fetch https://awesome.hatenablog.com/archive/2023 articles.jsonl
+    """
     fetch_parser = subparsers.add_parser(
-        "fetch", parents=[build_fetch_parser(add_help=False)]
+        "fetch",
+        parents=[build_fetch_parser(add_help=False)],
+        help="Fetch article titles only and save to file",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=dedent(fetch_help_message),
     )
     fetch_parser.set_defaults(func=fetch_cli)
 


### PR DESCRIPTION
Fixes #11

## Changes

- **Removed "Support" section from top-level help** - Moved to `fetch` subcommand where it belongs
- **Unhid `run` subcommand** - Removed `==SUPPRESS==` and added description: "Fetch article titles and generate summary (default)"
- **Added explicit description to `fetch` subcommand** - Includes "Support" section with list of supported sites

## Result

**Top-level help** (`omae-douyo --help`):
```
positional arguments:
  {run,fetch}
    run        Fetch article titles and generate summary (default)
    fetch      Fetch article titles only and save to file
```

**Fetch subcommand help** (`omae-douyo fetch --help`):
- Now displays "Support" section with all supported sites
- Better information architecture: feature details under relevant subcommand

All tests passing ✓