### PR TITLE
feat: Add note RSS fetcher

### DIFF
--- a/recent_state_summarizer/fetch/__init__.py
+++ b/recent_state_summarizer/fetch/__init__.py
@@ -7,6 +7,7 @@ from recent_state_summarizer.fetch.hatena_blog import _fetch_titles
 from recent_state_summarizer.fetch.hatena_bookmark import (
     fetch_hatena_bookmark_rss,
 )
+from recent_state_summarizer.fetch.note_rss import fetch_note_rss
 from recent_state_summarizer.fetch.qiita_advent_calendar import (
     fetch_qiita_advent_calendar,
 )

--- a/recent_state_summarizer/fetch/note_rss.py
+++ b/recent_state_summarizer/fetch/note_rss.py
@@ -1,0 +1,24 @@
+from collections.abc import Generator
+from urllib.parse import urlparse
+
+import feedparser
+import httpx
+
+from recent_state_summarizer.fetch.registry import register_fetcher
+from recent_state_summarizer.fetch.types import TitleTag
+
+
+def _match_note_rss(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.netloc == "note.com" and parsed.path.endswith("/rss")
+
+
+@register_fetcher(name="note RSS", matcher=_match_note_rss)
+def fetch_note_rss(url: str) -> Generator[TitleTag, None, None]:
+    response = httpx.get(url)
+    response.raise_for_status()
+
+    feed = feedparser.parse(response.content)
+
+    for entry in feed.entries:
+        yield {"title": entry.title, "url": entry.link}

--- a/tests/fetch/test_core.py
+++ b/tests/fetch/test_core.py
@@ -8,6 +8,7 @@ from recent_state_summarizer.fetch.hatena_blog import _fetch_titles
 from recent_state_summarizer.fetch.hatena_bookmark import (
     fetch_hatena_bookmark_rss,
 )
+from recent_state_summarizer.fetch.note_rss import fetch_note_rss
 from recent_state_summarizer.fetch.qiita_advent_calendar import (
     fetch_qiita_advent_calendar,
 )
@@ -75,6 +76,10 @@ class TestGetFetcher:
     def test_qiita_rss(self):
         url = "https://qiita.com/ftnext/feed.atom"
         assert get_fetcher(url) == fetch_qiita_rss
+
+    def test_note_rss(self):
+        url = "https://note.com/ftnext/rss"
+        assert get_fetcher(url) == fetch_note_rss
 
     def test_unknown_url_raises(self):
         url = "https://example.com/blog"

--- a/tests/fetch/test_note_rss.py
+++ b/tests/fetch/test_note_rss.py
@@ -1,0 +1,43 @@
+import httpx
+import respx
+
+from recent_state_summarizer.fetch.note_rss import fetch_note_rss
+
+
+class TestNoteRSS:
+    @respx.mock
+    def test_fetch_note_rss(self):
+        rss_feed = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>ftnext｜note</title>
+    <link>https://note.com/ftnext</link>
+    <description>ftnextさんの最近の記事</description>
+    <item>
+      <title>noteの記事タイトル1</title>
+      <link>https://note.com/ftnext/n/n1234567890ab</link>
+      <description>記事の説明1</description>
+    </item>
+    <item>
+      <title>noteの記事タイトル2</title>
+      <link>https://note.com/ftnext/n/ncdef01234567</link>
+      <description>記事の説明2</description>
+    </item>
+  </channel>
+</rss>"""
+        respx.get("https://note.com/ftnext/rss").mock(
+            return_value=httpx.Response(
+                status_code=200,
+                content=rss_feed.encode("utf-8"),
+                headers={"content-type": "application/xml"},
+            )
+        )
+
+        result = list(fetch_note_rss("https://note.com/ftnext/rss"))
+
+        assert len(result) == 2
+        assert result[0]["title"] == "noteの記事タイトル1"
+        assert result[0]["url"] == "https://note.com/ftnext/n/n1234567890ab"
+        assert result[1]["title"] == "noteの記事タイトル2"
+        assert result[1]["url"] == "https://note.com/ftnext/n/ncdef01234567"


### PR DESCRIPTION
## Summary
- Add `note_rss.py` fetcher to support fetching articles from `https://note.com/{username}/rss` feeds
- Uses feedparser + httpx following the same pattern as the Qiita RSS fetcher
- Registered in `fetch/__init__.py` so it auto-appears in help messages

Closes #17

## Test plan
- [x] Unit test for `fetch_note_rss` with mocked RSS response (`test_note_rss.py`)
- [x] `get_fetcher` URL matching test in `test_core.py`
- [x] Dynamic help message test automatically passes for "note RSS"
- [x] All 37 tests pass

https://claude.ai/code/session_014sLLHbFUiX8C3DwUdT6kDL