### PR TITLE
feat: Show supported URLs with examples in fetch help

### DIFF
--- a/recent_state_summarizer/fetch/adventar.py
+++ b/recent_state_summarizer/fetch/adventar.py
@@ -24,6 +24,7 @@ def _fetch(url: str) -> str:
 @register_fetcher(
     name="Adventar",
     matcher=_match_adventar,
+    example="https://adventar.org/calendars/1234",
 )
 def fetch_adventar_calendar(url: str) -> Generator[TitleTag, None, None]:
     """Fetch article titles and URLs from Adventar calendar.

--- a/recent_state_summarizer/fetch/cli.py
+++ b/recent_state_summarizer/fetch/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from recent_state_summarizer.fetch.registry import (
     get_fetcher,
+    get_registered_help_entries,
     get_registered_names,
 )
 from recent_state_summarizer.fetch.types import TitleTag
@@ -46,16 +47,21 @@ def _save(path: str | Path, contents: str) -> None:
 
 
 def _build_support_list() -> str:
-    names = get_registered_names()
-    return "\n".join(f"        - {name}" for name in names)
+    entries = get_registered_help_entries()
+    lines = []
+    for name, example in entries:
+        lines.append(f"        - {name}")
+        if example:
+            lines.append(f"          {example}")
+    return "\n".join(lines)
 
 
 def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
     help_message = f"""
-    Retrieve the titles and URLs of articles from a web page specified by URL
+    Retrieve the titles and URLs of articles from a web page specified by <URL>
     and save them as JSON Lines format.
 
-    Support:
+    Supported URLs:
 {_build_support_list()}
 
     Example:

--- a/recent_state_summarizer/fetch/hatena_blog.py
+++ b/recent_state_summarizer/fetch/hatena_blog.py
@@ -26,6 +26,7 @@ def _fetch(url: str) -> str:
 @register_fetcher(
     name="はてなブログ（Hatena blog）",
     matcher=_match_hatena_blog,
+    example="https://awesome.hatenablog.com/archive/2023",
 )
 def _fetch_titles(url: str) -> Generator[TitleTag, None, None]:
     raw_html = _fetch(url)

--- a/recent_state_summarizer/fetch/hatena_bookmark.py
+++ b/recent_state_summarizer/fetch/hatena_bookmark.py
@@ -25,6 +25,7 @@ class BookmarkEntry(TypedDict):
 @register_fetcher(
     name="はてなブックマークRSS",
     matcher=_match_hatena_bookmark_rss,
+    example="https://b.hatena.ne.jp/entrylist/user.rss",
 )
 def fetch_hatena_bookmark_rss(
     url: str,

--- a/recent_state_summarizer/fetch/note_rss.py
+++ b/recent_state_summarizer/fetch/note_rss.py
@@ -13,7 +13,11 @@ def _match_note_rss(url: str) -> bool:
     return parsed.netloc == "note.com" and parsed.path.endswith("/rss")
 
 
-@register_fetcher(name="note RSS", matcher=_match_note_rss)
+@register_fetcher(
+    name="note RSS",
+    matcher=_match_note_rss,
+    example="https://note.com/user/rss",
+)
 def fetch_note_rss(url: str) -> Generator[TitleTag, None, None]:
     response = httpx.get(url)
     response.raise_for_status()

--- a/recent_state_summarizer/fetch/qiita_advent_calendar.py
+++ b/recent_state_summarizer/fetch/qiita_advent_calendar.py
@@ -23,6 +23,7 @@ def _fetch(url: str) -> str:
 @register_fetcher(
     name="Qiita Advent Calendar",
     matcher=_match_qiita_advent_calendar,
+    example="https://qiita.com/advent-calendar/2023/python",
 )
 def fetch_qiita_advent_calendar(url: str) -> Generator[TitleTag, None, None]:
     """Fetch article titles and URLs from Qiita Advent Calendar.

--- a/recent_state_summarizer/fetch/qiita_api.py
+++ b/recent_state_summarizer/fetch/qiita_api.py
@@ -12,7 +12,11 @@ def _match_qiita_api(url: str) -> bool:
     return parsed.netloc == "qiita.com" and "/api/v2/users/" in parsed.path
 
 
-@register_fetcher(name="Qiita API v2", matcher=_match_qiita_api)
+@register_fetcher(
+    name="Qiita API v2",
+    matcher=_match_qiita_api,
+    example="https://qiita.com/api/v2/users/user/items",
+)
 def fetch_qiita_api(url: str) -> Generator[TitleTag, None, None]:
     response = httpx.get(url, params={"per_page": 20})
     response.raise_for_status()

--- a/recent_state_summarizer/fetch/qiita_rss.py
+++ b/recent_state_summarizer/fetch/qiita_rss.py
@@ -13,7 +13,11 @@ def _match_qiita_rss(url: str) -> bool:
     return parsed.netloc == "qiita.com" and parsed.path.endswith("/feed.atom")
 
 
-@register_fetcher(name="Qiita RSS", matcher=_match_qiita_rss)
+@register_fetcher(
+    name="Qiita RSS",
+    matcher=_match_qiita_rss,
+    example="https://qiita.com/user/feed.atom",
+)
 def fetch_qiita_rss(url: str) -> Generator[TitleTag, None, None]:
     response = httpx.get(url)
     response.raise_for_status()

--- a/recent_state_summarizer/fetch/registry.py
+++ b/recent_state_summarizer/fetch/registry.py
@@ -9,22 +9,25 @@ if TYPE_CHECKING:
 Fetcher = Callable[[str], Generator["TitleTag", None, None]]
 URLMatcher = Callable[[str], bool]
 
-_registry: list[tuple[str, URLMatcher, Fetcher]] = []
+_registry: list[tuple[str, URLMatcher, Fetcher, str]] = []
 
 
 def register_fetcher(
     name: str,
     matcher: URLMatcher,
+    *,
+    example: str = "",
 ) -> Callable[[Fetcher], Fetcher]:
     """Decorator to register a fetcher with a URL matcher.
 
     Args:
         name: Human-readable name for the fetcher (used in help messages)
         matcher: Function that takes a URL and returns True if this fetcher handles it
+        example: Example URL for the fetcher (used in help messages)
     """
 
     def decorator(func: Fetcher) -> Fetcher:
-        _registry.append((name, matcher, func))
+        _registry.append((name, matcher, func, example))
         return func
 
     return decorator
@@ -36,7 +39,7 @@ def get_fetcher(url: str) -> Fetcher:
     Raises:
         ValueError: If no fetcher matches the URL
     """
-    for name, matcher, fetcher in _registry:
+    for name, matcher, fetcher, _ in _registry:
         if matcher(url):
             return fetcher
     raise ValueError(f"Unsupported URL: {url}")
@@ -44,4 +47,9 @@ def get_fetcher(url: str) -> Fetcher:
 
 def get_registered_names() -> list[str]:
     """Get list of registered fetcher names for help messages."""
-    return [name for name, _, _ in _registry]
+    return [name for name, _, _, _ in _registry]
+
+
+def get_registered_help_entries() -> list[tuple[str, str]]:
+    """Get list of (name, example) pairs for help messages."""
+    return [(name, example) for name, _, _, example in _registry]


### PR DESCRIPTION
## Summary
- `register_fetcher` デコレータに `example` キーワード引数を追加し、各フェッチャーが例URLを自己登録できるようにした
- fetchコマンドのヘルプで、説明文を `<URL>` プレースホルダーに変更し、「Supported URLs」セクションでフェッチャー名とURL例を並べて表示するようにした
- 新しいフェッチャーを追加すると、ヘルプに自動で名前と例URLが反映される

### Before
```
Support:
    - Adventar
    - はてなブログ（Hatena blog）
    ...
```

### After
```
Supported URLs:
    - Adventar
      https://adventar.org/calendars/1234
    - はてなブログ（Hatena blog）
      https://awesome.hatenablog.com/archive/2023
    ...
```

## Test plan
- [x] 既存の全34テストが通ることを確認
- [x] `python -m recent_state_summarizer.fetch -h` で新しいヘルプが表示されることを確認
- [x] `omae-douyo fetch -h` でも同様に表示されることを確認

https://claude.ai/code/session_013oUPHuBHArDnqimoRzNgHD