### PR TITLE
fix: Update Adventar fetcher for new HTML structure (fixes #30)

### DIFF
--- a/recent_state_summarizer/fetch/adventar.py
+++ b/recent_state_summarizer/fetch/adventar.py
@@ -45,13 +45,13 @@ def _parse_titles(raw_html: str) -> Generator[TitleTag, None, None]:
     if not entry_list:
         return
 
-    items = entry_list.find_all("li", class_="item")
+    items = entry_list.find_all("li", class_="EntryList-item")
     for item in items:
-        article = item.find("div", class_="article")
+        article = item.find("div", class_="EntryList-article")
         if not article:
             continue
 
-        link_div = article.find("div", class_="link")
+        link_div = article.find("div", class_="EntryList-link")
         if not link_div:
             continue
 

--- a/tests/fetch/test_adventar.py
+++ b/tests/fetch/test_adventar.py
@@ -11,39 +11,39 @@ def test_fetch_adventar_as_bullet_list(tmp_path):
 <html>
 <body>
 <ul class="EntryList">
-  <li class="item">
-    <div class="head">
-      <div class="date">12/2</div>
+  <li class="EntryList-item">
+    <div class="EntryList-head">
+      <div class="EntryList-date">12/2</div>
     </div>
-    <div class="comment">アニメを見続ける技術</div>
-    <div class="article">
-      <div class="left">
-        <div class="link">
+    <div class="EntryList-comment">アニメを見続ける技術</div>
+    <div class="EntryList-article">
+      <div class="EntryList-articleBody">
+        <div class="EntryList-link">
           <a href="https://example.com/article1">https://example.com/article1</a>
         </div>
         <div>アニメを見続ける技術 あるいは 習慣化について｜こうの</div>
       </div>
     </div>
   </li>
-  <li class="item">
-    <div class="head">
-      <div class="date">12/3</div>
+  <li class="EntryList-item">
+    <div class="EntryList-head">
+      <div class="EntryList-date">12/3</div>
     </div>
-    <div class="comment">崎山香織は諦めない</div>
-    <div class="article">
-      <div class="left">
-        <div class="link">
+    <div class="EntryList-comment">崎山香織は諦めない</div>
+    <div class="EntryList-article">
+      <div class="EntryList-articleBody">
+        <div class="EntryList-link">
           <a href="https://example.com/article2">https://example.com/article2</a>
         </div>
         <div>崎山香織は諦めない~決して勝てぬ者こそが届く高み｜keita</div>
       </div>
     </div>
   </li>
-  <li class="item">
-    <div class="head">
-      <div class="date">12/4</div>
+  <li class="EntryList-item">
+    <div class="EntryList-head">
+      <div class="EntryList-date">12/4</div>
     </div>
-    <div class="comment">記事なし</div>
+    <div class="EntryList-comment">記事なし</div>
   </li>
 </ul>
 </body>
@@ -74,39 +74,39 @@ def test_fetch_adventar_as_json(tmp_path):
 <html>
 <body>
 <ul class="EntryList">
-  <li class="item">
-    <div class="head">
-      <div class="date">12/2</div>
+  <li class="EntryList-item">
+    <div class="EntryList-head">
+      <div class="EntryList-date">12/2</div>
     </div>
-    <div class="comment">アニメを見続ける技術</div>
-    <div class="article">
-      <div class="left">
-        <div class="link">
+    <div class="EntryList-comment">アニメを見続ける技術</div>
+    <div class="EntryList-article">
+      <div class="EntryList-articleBody">
+        <div class="EntryList-link">
           <a href="https://example.com/article1">https://example.com/article1</a>
         </div>
         <div>アニメを見続ける技術 あるいは 習慣化について｜こうの</div>
       </div>
     </div>
   </li>
-  <li class="item">
-    <div class="head">
-      <div class="date">12/3</div>
+  <li class="EntryList-item">
+    <div class="EntryList-head">
+      <div class="EntryList-date">12/3</div>
     </div>
-    <div class="comment">崎山香織は諦めない</div>
-    <div class="article">
-      <div class="left">
-        <div class="link">
+    <div class="EntryList-comment">崎山香織は諦めない</div>
+    <div class="EntryList-article">
+      <div class="EntryList-articleBody">
+        <div class="EntryList-link">
           <a href="https://example.com/article2">https://example.com/article2</a>
         </div>
         <div>崎山香織は諦めない~決して勝てぬ者こそが届く高み｜keita</div>
       </div>
     </div>
   </li>
-  <li class="item">
-    <div class="head">
-      <div class="date">12/4</div>
+  <li class="EntryList-item">
+    <div class="EntryList-head">
+      <div class="EntryList-date">12/4</div>
     </div>
-    <div class="comment">記事なし</div>
+    <div class="EntryList-comment">記事なし</div>
   </li>
 </ul>
 </body>


### PR DESCRIPTION
## 概要

Adventar の fetcher が記事を1件も取得できず空の結果を返す問題を修正します。

Fixes #30

## 原因

Adventar 側の HTML 構造が変更され、クラス名が BEM 形式になっていました。fetcher は旧クラス名を探していたため、`<ul class="EntryList">` 以下にマッチせず 0 件になっていました。例外も発生しないため気づきにくい状態でした。

| 旧（コードが探していた） | 新（実際の HTML） |
|---|---|
| `li.item` | `li.EntryList-item` |
| `div.article` | `div.EntryList-article` |
| `div.link` | `div.EntryList-link` |

タイトルが `EntryList-link` の次の兄弟 `<div>` にある構造は変わっていないため、そこは変更していません。

## 変更内容

- `recent_state_summarizer/fetch/adventar.py`: セレクタを新クラス名に更新（最小diff）
- `tests/fetch/test_adventar.py`: fixture の HTML を実際の新構造に合わせて更新

## 確認

- 実際の fetch (`omae-douyo fetch https://adventar.org/calendars/11354`) で 24 件取得を確認（リンク未登録の枠は正しくスキップ）
- `python -m pytest -v` => 37 passed
- `uvx black -l 79 --check` => 問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
