### PR TITLE
feat: Add GitHub Changelog RSS fetcher

### DIFF
--- a/recent_state_summarizer/fetch/__init__.py
+++ b/recent_state_summarizer/fetch/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from recent_state_summarizer.fetch.adventar import fetch_adventar_calendar
+from recent_state_summarizer.fetch.github_changelog import (
+    fetch_github_changelog,
+)
 from recent_state_summarizer.fetch.hatena_blog import _fetch_titles
 
 # Fetcher registration imports (required for @register_fetcher decorator)

--- a/recent_state_summarizer/fetch/github_changelog.py
+++ b/recent_state_summarizer/fetch/github_changelog.py
@@ -1,0 +1,27 @@
+from collections.abc import Generator
+from urllib.parse import urlparse
+
+import feedparser
+import httpx
+
+from recent_state_summarizer.fetch.registry import register_fetcher
+from recent_state_summarizer.fetch.types import TitleTag
+
+
+def _match_github_changelog(url: str) -> bool:
+    parsed = urlparse(url)
+    return (
+        parsed.netloc == "github.blog"
+        and parsed.path.rstrip("/") == "/changelog/feed"
+    )
+
+
+@register_fetcher(name="GitHub Changelog", matcher=_match_github_changelog)
+def fetch_github_changelog(url: str) -> Generator[TitleTag, None, None]:
+    response = httpx.get(url)
+    response.raise_for_status()
+
+    feed = feedparser.parse(response.content)
+
+    for entry in feed.entries:
+        yield {"title": entry.title, "url": entry.link}

--- a/tests/fetch/test_core.py
+++ b/tests/fetch/test_core.py
@@ -4,6 +4,9 @@ import pytest
 
 from recent_state_summarizer.fetch.adventar import fetch_adventar_calendar
 from recent_state_summarizer.fetch.cli import cli
+from recent_state_summarizer.fetch.github_changelog import (
+    fetch_github_changelog,
+)
 from recent_state_summarizer.fetch.hatena_blog import _fetch_titles
 from recent_state_summarizer.fetch.hatena_bookmark import (
     fetch_hatena_bookmark_rss,
@@ -80,6 +83,10 @@ class TestGetFetcher:
     def test_note_rss(self):
         url = "https://note.com/ftnext/rss"
         assert get_fetcher(url) == fetch_note_rss
+
+    def test_github_changelog(self):
+        url = "https://github.blog/changelog/feed/"
+        assert get_fetcher(url) == fetch_github_changelog
 
     def test_unknown_url_raises(self):
         url = "https://example.com/blog"

--- a/tests/fetch/test_github_changelog.py
+++ b/tests/fetch/test_github_changelog.py
@@ -1,0 +1,61 @@
+import httpx
+import respx
+
+from recent_state_summarizer.fetch.github_changelog import (
+    fetch_github_changelog,
+)
+
+
+class TestGitHubChangelog:
+    @respx.mock
+    def test_fetch_github_changelog(self):
+        rss_feed = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+>
+<channel>
+  <title>The GitHub Blog: GitHub Changelog</title>
+  <link>https://github.blog/changelog</link>
+  <description>Subscribe to Changelog</description>
+  <item>
+    <title>Changelog entry 1</title>
+    <link>https://github.blog/changelog/2026-07-01-entry-1/</link>
+    <dc:creator><![CDATA[Author 1]]></dc:creator>
+    <description><![CDATA[<p>Description 1</p>]]></description>
+    <content:encoded><![CDATA[<p>Content 1</p>]]></content:encoded>
+  </item>
+  <item>
+    <title>Changelog entry 2</title>
+    <link>https://github.blog/changelog/2026-07-02-entry-2/</link>
+    <dc:creator><![CDATA[Author 2]]></dc:creator>
+    <description><![CDATA[<p>Description 2</p>]]></description>
+    <content:encoded><![CDATA[<p>Content 2</p>]]></content:encoded>
+  </item>
+</channel>
+</rss>"""
+        respx.get("https://github.blog/changelog/feed/").mock(
+            return_value=httpx.Response(
+                status_code=200,
+                content=rss_feed.encode("utf-8"),
+                headers={"content-type": "application/rss+xml"},
+            )
+        )
+
+        result = list(
+            fetch_github_changelog("https://github.blog/changelog/feed/")
+        )
+
+        assert len(result) == 2
+        assert result[0]["title"] == "Changelog entry 1"
+        assert (
+            result[0]["url"]
+            == "https://github.blog/changelog/2026-07-01-entry-1/"
+        )
+        assert result[1]["title"] == "Changelog entry 2"
+        assert (
+            result[1]["url"]
+            == "https://github.blog/changelog/2026-07-02-entry-2/"
+        )


### PR DESCRIPTION
## 概要

GitHub Changelog フィード (`https://github.blog/changelog/feed/`) から記事タイトルを取得できるフェッチャーを追加しました。既存の RSS フェッチャー（`note_rss` / `qiita_rss` など）と同じ feedparser ベースのパターンに揃えています。

```bash
omae-douyo https://github.blog/changelog/feed/
```

## 変更内容

- `recent_state_summarizer/fetch/github_changelog.py`: 新規フェッチャー。`netloc == "github.blog"` かつパスが `/changelog/feed` のときにマッチ
- `recent_state_summarizer/fetch/__init__.py`: デコレータ登録をトリガーする import を1行追加
- `tests/fetch/test_github_changelog.py`: respx でフィードをモックしパース結果を検証
- `tests/fetch/test_core.py`: レジストリによる URL 解決テストを追加

レジストリパターンにより、動的ヘルプメッセージにも `GitHub Changelog` が自動で表示されます。

## テスト

`python -m pytest -v` — 全 40 件パス。

## 補足

このセッションのネットワークポリシーで `github.blog` への直接アクセスがブロックされているため、実フィードへのライブ疎通確認は未実施です。フィード構造を模したサンプル XML でパースロジックを検証しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUBXvugV1eCtUmAM2UZvYR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUBXvugV1eCtUmAM2UZvYR)_