### PR TITLE
feat: Qiita公式イベントページから記事一覧を取得できるようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Adventar calendars
 - Qiita Advent Calendar
 - Qiita RSS (user feeds)
+- Qiita Official Event (公式イベント)
 
 The main CLI command is `omae-douyo` which fetches titles and generates a summary in Japanese.
 
@@ -114,6 +115,7 @@ The fetcher system uses a registry pattern where each fetcher self-registers:
    - `adventar.py`: Uses httpx + BeautifulSoup to parse Adventar calendar pages
    - `qiita_advent_calendar.py`: Uses httpx + BeautifulSoup to extract JSON data from Qiita Advent Calendar pages
    - `qiita_rss.py`: Parses Atom feeds with feedparser (user RSS feeds)
+   - `qiita_official_event.py`: Uses httpx + BeautifulSoup to extract JSON data from Qiita official event pages, following `?page=N` pagination via `pageData.nextPage`
 
 All fetchers yield `TitleTag` TypedDict objects with `title` and `url` keys.
 

--- a/recent_state_summarizer/fetch/__init__.py
+++ b/recent_state_summarizer/fetch/__init__.py
@@ -15,4 +15,7 @@ from recent_state_summarizer.fetch.qiita_advent_calendar import (
     fetch_qiita_advent_calendar,
 )
 from recent_state_summarizer.fetch.qiita_api import fetch_qiita_api
+from recent_state_summarizer.fetch.qiita_official_event import (
+    fetch_qiita_official_event,
+)
 from recent_state_summarizer.fetch.qiita_rss import fetch_qiita_rss

--- a/recent_state_summarizer/fetch/qiita_official_event.py
+++ b/recent_state_summarizer/fetch/qiita_official_event.py
@@ -1,0 +1,58 @@
+import json
+from collections.abc import Generator
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from bs4 import BeautifulSoup
+
+from recent_state_summarizer.fetch.registry import register_fetcher
+from recent_state_summarizer.fetch.types import TitleTag
+
+
+def _match_qiita_official_event(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.netloc == "qiita.com" and parsed.path.startswith(
+        "/official-events/"
+    )
+
+
+@register_fetcher(
+    name="Qiita Official Event",
+    matcher=_match_qiita_official_event,
+)
+def fetch_qiita_official_event(url: str) -> Generator[TitleTag, None, None]:
+    """Fetch article titles and URLs from Qiita official event.
+
+    Args:
+        url: Qiita official event URL (e.g., https://qiita.com/official-events/bd14d28b53326d318fec)
+
+    Yields:
+        TitleTag dictionaries containing title and url
+    """
+    page = 1
+    while page:
+        response = httpx.get(url, params={"page": page})
+        response.raise_for_status()
+
+        paginated_articles = _parse_paginated_articles(response.text)
+        if paginated_articles is None:
+            return
+
+        for item in paginated_articles["items"]:
+            yield {"title": item["title"], "url": item["linkUrl"]}
+
+        page = paginated_articles["pageData"]["nextPage"]
+
+
+def _parse_paginated_articles(raw_html: str) -> dict[str, Any] | None:
+    soup = BeautifulSoup(raw_html, "html.parser")
+    script_tag = soup.find(
+        "script",
+        attrs={"data-component-name": "PostingCampaignDetailPage"},
+    )
+    if not script_tag or not script_tag.string:
+        return None
+
+    data = json.loads(script_tag.string)
+    return data["postingCampaign"]["paginatedPostingCampaignArticles"]

--- a/tests/fetch/test_core.py
+++ b/tests/fetch/test_core.py
@@ -15,6 +15,9 @@ from recent_state_summarizer.fetch.note_rss import fetch_note_rss
 from recent_state_summarizer.fetch.qiita_advent_calendar import (
     fetch_qiita_advent_calendar,
 )
+from recent_state_summarizer.fetch.qiita_official_event import (
+    fetch_qiita_official_event,
+)
 from recent_state_summarizer.fetch.qiita_rss import fetch_qiita_rss
 from recent_state_summarizer.fetch.registry import get_fetcher
 
@@ -79,6 +82,10 @@ class TestGetFetcher:
     def test_qiita_rss(self):
         url = "https://qiita.com/ftnext/feed.atom"
         assert get_fetcher(url) == fetch_qiita_rss
+
+    def test_qiita_official_event(self):
+        url = "https://qiita.com/official-events/bd14d28b53326d318fec"
+        assert get_fetcher(url) == fetch_qiita_official_event
 
     def test_note_rss(self):
         url = "https://note.com/ftnext/rss"

--- a/tests/fetch/test_qiita_official_event.py
+++ b/tests/fetch/test_qiita_official_event.py
@@ -1,0 +1,134 @@
+import httpx
+import respx
+
+from recent_state_summarizer.fetch.cli import _main
+
+EVENT_URL = "https://qiita.com/official-events/bd14d28b53326d318fec"
+
+
+def build_html_response(items, next_page):
+    articles = ",".join(f"""{{
+              "title": "{title}",
+              "linkUrl": "{url}"
+            }}""" for title, url in items)
+    return f"""\
+<!DOCTYPE html>
+<html>
+<body>
+<script type="application/json" data-component-name="PostingCampaignDetailPage">
+{{
+  "postingCampaign": {{
+    "paginatedPostingCampaignArticles": {{
+      "items": [{articles}],
+      "pageData": {{"nextPage": {next_page}}}
+    }}
+  }}
+}}
+</script>
+</body>
+</html>"""
+
+
+@respx.mock
+def test_fetch_qiita_official_event_as_bullet_list(tmp_path):
+    respx.get(EVENT_URL, params={"page": 1}).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            text=build_html_response(
+                [
+                    (
+                        "さくらのAI Engineを試す",
+                        "https://qiita.com/user1/items/abc123",
+                    )
+                ],
+                next_page="null",
+            ),
+        )
+    )
+
+    _main(EVENT_URL, tmp_path / "titles.txt", save_as_title_list=True)
+
+    expected = "- さくらのAI Engineを試す"
+    assert (tmp_path / "titles.txt").read_text(encoding="utf8") == expected
+
+
+@respx.mock
+def test_fetch_qiita_official_event_as_json(tmp_path):
+    respx.get(EVENT_URL, params={"page": 1}).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            text=build_html_response(
+                [
+                    (
+                        "さくらのAI Engineを試す",
+                        "https://qiita.com/user1/items/abc123",
+                    )
+                ],
+                next_page="null",
+            ),
+        )
+    )
+
+    _main(EVENT_URL, tmp_path / "titles.jsonl", save_as_title_list=False)
+
+    expected = (
+        '{"title": "さくらのAI Engineを試す", '
+        '"url": "https://qiita.com/user1/items/abc123"}'
+    )
+    assert (tmp_path / "titles.jsonl").read_text(encoding="utf8") == expected
+
+
+@respx.mock
+def test_fetch_qiita_official_event_follows_pagination(tmp_path):
+    respx.get(EVENT_URL, params={"page": 1}).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            text=build_html_response(
+                [("1ページ目の記事", "https://qiita.com/user1/items/abc123")],
+                next_page="2",
+            ),
+        )
+    )
+    respx.get(EVENT_URL, params={"page": 2}).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            text=build_html_response(
+                [("2ページ目の記事", "https://qiita.com/user2/items/def456")],
+                next_page="null",
+            ),
+        )
+    )
+
+    _main(EVENT_URL, tmp_path / "titles.txt", save_as_title_list=True)
+
+    expected = """\
+- 1ページ目の記事
+- 2ページ目の記事"""
+    assert (tmp_path / "titles.txt").read_text(encoding="utf8") == expected
+
+
+@respx.mock
+def test_fetch_qiita_official_event_with_fragment(tmp_path):
+    respx.get(EVENT_URL, params={"page": 1}).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            text=build_html_response(
+                [
+                    (
+                        "さくらのAI Engineを試す",
+                        "https://qiita.com/user1/items/abc123",
+                    )
+                ],
+                next_page="null",
+            ),
+        )
+    )
+
+    _main(
+        f"{EVENT_URL}#posted-articles",
+        tmp_path / "titles.txt",
+        save_as_title_list=True,
+    )
+
+    expected = "- さくらのAI Engineを試す"
+    assert (tmp_path / "titles.txt").read_text(encoding="utf8") == expected


### PR DESCRIPTION
## 概要

Qiitaの公式イベントページ（`https://qiita.com/official-events/<uuid>`）から、投稿された記事の一覧を取得できるようにしました。

これまでは Qiita 向けの matcher が Advent Calendar / RSS / API v2 の3つだけで、公式イベントのURLは `Unsupported URL` になっていました。

```bash
omae-douyo fetch https://qiita.com/official-events/bd14d28b53326d318fec titles.txt --as-title-list
```

## 実装のポイント

- 記事データはHTMLに埋め込まれた `<script data-component-name="PostingCampaignDetailPage">` のJSONから抽出します（Qiita Advent Calendar fetcher と同じパターン）
- 1ページ20件なので `?page=N` でページ送りし、`pageData.nextPage` が `null` になるまで辿ります
- URLの組み立ては `httpx` の `params=` に任せているため、ページ内アンカー付きのURL（`.../<uuid>#posted-articles`）を渡しても正しく `?page=N#posted-articles` になります

なお `/posted-articles` は独立したパスではなくページ内アンカー（`#posted-articles`）で、直接叩くと404になります。そのため matcher は `/official-events/` で始まるpathを対象にしています。

## 変更内容

- `recent_state_summarizer/fetch/qiita_official_event.py` を追加
- `recent_state_summarizer/fetch/__init__.py` に登録用のimportを追加
- `tests/fetch/test_qiita_official_event.py` を追加（bullet list / JSON Lines / ページ送り / アンカー付きURL）
- `tests/fetch/test_core.py` に `get_fetcher` のテストを追加
- CLAUDE.md を更新

## テスト

- `python -m pytest -v` : 46 passed
- 実際のイベントページに対して動作確認済み（44件取得、`totalCount` と一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)