### PR TITLE
feat: Add Zenn RSS fetcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Qiita Advent Calendar
 - Qiita RSS (user feeds)
 - Qiita Official Event (公式イベント)
+- Zenn RSS (user feeds)
 
 The main CLI command is `omae-douyo` which fetches titles and generates a summary in Japanese.
 
@@ -116,6 +117,7 @@ The fetcher system uses a registry pattern where each fetcher self-registers:
    - `qiita_advent_calendar.py`: Uses httpx + BeautifulSoup to extract JSON data from Qiita Advent Calendar pages
    - `qiita_rss.py`: Parses Atom feeds with feedparser (user RSS feeds)
    - `qiita_official_event.py`: Uses httpx + BeautifulSoup to extract JSON data from Qiita official event pages, following `?page=N` pagination via `pageData.nextPage`
+   - `zenn_rss.py`: Parses RSS feeds with feedparser (user feeds, `https://zenn.dev/{username}/feed?all=1`)
 
 All fetchers yield `TitleTag` TypedDict objects with `title` and `url` keys.
 

--- a/recent_state_summarizer/fetch/__init__.py
+++ b/recent_state_summarizer/fetch/__init__.py
@@ -19,3 +19,4 @@ from recent_state_summarizer.fetch.qiita_official_event import (
     fetch_qiita_official_event,
 )
 from recent_state_summarizer.fetch.qiita_rss import fetch_qiita_rss
+from recent_state_summarizer.fetch.zenn_rss import fetch_zenn_rss

--- a/recent_state_summarizer/fetch/zenn_rss.py
+++ b/recent_state_summarizer/fetch/zenn_rss.py
@@ -1,0 +1,24 @@
+from collections.abc import Generator
+from urllib.parse import urlparse
+
+import feedparser
+import httpx
+
+from recent_state_summarizer.fetch.registry import register_fetcher
+from recent_state_summarizer.fetch.types import TitleTag
+
+
+def _match_zenn_rss(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.netloc == "zenn.dev" and parsed.path.endswith("/feed")
+
+
+@register_fetcher(name="Zenn RSS", matcher=_match_zenn_rss)
+def fetch_zenn_rss(url: str) -> Generator[TitleTag, None, None]:
+    response = httpx.get(url)
+    response.raise_for_status()
+
+    feed = feedparser.parse(response.content)
+
+    for entry in feed.entries:
+        yield {"title": entry.title, "url": entry.link}

--- a/tests/fetch/test_core.py
+++ b/tests/fetch/test_core.py
@@ -20,6 +20,7 @@ from recent_state_summarizer.fetch.qiita_official_event import (
 )
 from recent_state_summarizer.fetch.qiita_rss import fetch_qiita_rss
 from recent_state_summarizer.fetch.registry import get_fetcher
+from recent_state_summarizer.fetch.zenn_rss import fetch_zenn_rss
 
 
 @patch("recent_state_summarizer.fetch.cli._main")
@@ -90,6 +91,10 @@ class TestGetFetcher:
     def test_note_rss(self):
         url = "https://note.com/ftnext/rss"
         assert get_fetcher(url) == fetch_note_rss
+
+    def test_zenn_rss(self):
+        url = "https://zenn.dev/ftnext/feed?all=1"
+        assert get_fetcher(url) == fetch_zenn_rss
 
     def test_github_changelog(self):
         url = "https://github.blog/changelog/feed/"

--- a/tests/fetch/test_zenn_rss.py
+++ b/tests/fetch/test_zenn_rss.py
@@ -1,0 +1,53 @@
+import httpx
+import respx
+
+from recent_state_summarizer.fetch.zenn_rss import fetch_zenn_rss
+
+
+class TestZennRSS:
+    @respx.mock
+    def test_fetch_zenn_rss(self):
+        rss_feed = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>nikkieさんのフィード</title>
+    <description>Zennのnikkieさん（@ftnext）のRSSフィードです</description>
+    <link>https://zenn.dev/ftnext</link>
+    <generator>zenn.dev</generator>
+    <lastBuildDate>Sun, 18 Jan 2026 02:11:47 GMT</lastBuildDate>
+    <atom:link href="https://zenn.dev/ftnext/feed" rel="self" type="application/rss+xml"/>
+    <language>ja</language>
+    <item>
+      <title>Zennの記事タイトル1</title>
+      <description>記事1です...</description>
+      <link>https://zenn.dev/ftnext/articles/abc123</link>
+      <guid isPermaLink="true">https://zenn.dev/ftnext/articles/abc123</guid>
+      <pubDate>Thu, 18 Dec 2025 23:44:21 GMT</pubDate>
+      <dc:creator>nikkie</dc:creator>
+    </item>
+    <item>
+      <title>Zennの記事タイトル2</title>
+      <description>記事2です...</description>
+      <link>https://zenn.dev/ftnext/articles/def456</link>
+      <guid isPermaLink="true">https://zenn.dev/ftnext/articles/def456</guid>
+      <pubDate>Thu, 18 Nov 2025 14:09:57 GMT</pubDate>
+      <dc:creator>nikkie</dc:creator>
+    </item>
+  </channel>
+</rss>"""
+        respx.get("https://zenn.dev/ftnext/feed", params={"all": "1"}).mock(
+            return_value=httpx.Response(
+                status_code=200,
+                content=rss_feed.encode("utf-8"),
+                headers={"content-type": "application/rss+xml"},
+            )
+        )
+
+        result = list(fetch_zenn_rss("https://zenn.dev/ftnext/feed?all=1"))
+
+        assert len(result) == 2
+        assert result[0]["title"] == "Zennの記事タイトル1"
+        assert result[0]["url"] == "https://zenn.dev/ftnext/articles/abc123"
+        assert result[1]["title"] == "Zennの記事タイトル2"
+        assert result[1]["url"] == "https://zenn.dev/ftnext/articles/def456"


### PR DESCRIPTION
## Summary
Zenn のユーザーRSSフィード（`https://zenn.dev/{username}/feed?all=1`）から記事タイトルとURLを取得する fetcher を追加しました。

Closes #16

## Implementation
- `recent_state_summarizer/fetch/zenn_rss.py`: httpx + feedparser で RSS をパース（`note_rss.py` / `qiita_rss.py` と同じ形）
  - matcher: netloc が `zenn.dev` かつ path が `/feed` で終わる（`?all=1` の有無に関わらずマッチ）
- `recent_state_summarizer/fetch/__init__.py`: 登録用の import を1行追加
- `CLAUDE.md`: サポート一覧と fetcher 実装一覧に追記

## Test
- `tests/fetch/test_zenn_rss.py`: respx で RSS レスポンスをモックして title/url を検証
- `tests/fetch/test_core.py`: `get_fetcher()` が Zenn URL で `fetch_zenn_rss` を返すことを検証
- `python -m pytest -v` → 49 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)