### PR TITLE
feat: Add Zenn contest fetcher (experimental)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Qiita RSS (user feeds)
 - Qiita Official Event (公式イベント)
 - Zenn RSS (user feeds)
+- Zenn Contest (experimental)
 
 The main CLI command is `omae-douyo` which fetches titles and generates a summary in Japanese.
 
@@ -118,6 +119,7 @@ The fetcher system uses a registry pattern where each fetcher self-registers:
    - `qiita_rss.py`: Parses Atom feeds with feedparser (user RSS feeds)
    - `qiita_official_event.py`: Uses httpx + BeautifulSoup to extract JSON data from Qiita official event pages, following `?page=N` pagination via `pageData.nextPage`
    - `zenn_rss.py`: Parses RSS feeds with feedparser (user feeds, `https://zenn.dev/{username}/feed?all=1`)
+   - `zenn_contest.py`: Uses httpx to call the undocumented `https://zenn.dev/api/articles?contest_slug={slug}` JSON API, following pagination via `next_page` (experimental: Zenn publishes neither a contest RSS feed nor this API's specification)
 
 All fetchers yield `TitleTag` TypedDict objects with `title` and `url` keys.
 

--- a/recent_state_summarizer/fetch/__init__.py
+++ b/recent_state_summarizer/fetch/__init__.py
@@ -19,4 +19,5 @@ from recent_state_summarizer.fetch.qiita_official_event import (
     fetch_qiita_official_event,
 )
 from recent_state_summarizer.fetch.qiita_rss import fetch_qiita_rss
+from recent_state_summarizer.fetch.zenn_contest import fetch_zenn_contest
 from recent_state_summarizer.fetch.zenn_rss import fetch_zenn_rss

--- a/recent_state_summarizer/fetch/zenn_contest.py
+++ b/recent_state_summarizer/fetch/zenn_contest.py
@@ -12,7 +12,11 @@ ZENN_ARTICLES_API_URL = f"{ZENN_ORIGIN}/api/articles"
 
 def _match_zenn_contest(url: str) -> bool:
     parsed = urlparse(url)
-    return parsed.netloc == "zenn.dev" and parsed.path.startswith("/contests/")
+    return (
+        parsed.netloc == "zenn.dev"
+        and parsed.path.startswith("/contests/")
+        and bool(_extract_contest_slug(url))
+    )
 
 
 @register_fetcher(

--- a/recent_state_summarizer/fetch/zenn_contest.py
+++ b/recent_state_summarizer/fetch/zenn_contest.py
@@ -1,0 +1,60 @@
+from collections.abc import Generator
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from recent_state_summarizer.fetch.registry import register_fetcher
+from recent_state_summarizer.fetch.types import TitleTag
+
+ZENN_ORIGIN = "https://zenn.dev"
+ZENN_ARTICLES_API_URL = f"{ZENN_ORIGIN}/api/articles"
+
+
+def _match_zenn_contest(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.netloc == "zenn.dev" and parsed.path.startswith("/contests/")
+
+
+@register_fetcher(
+    name="Zenn Contest (experimental)",
+    matcher=_match_zenn_contest,
+)
+def fetch_zenn_contest(url: str) -> Generator[TitleTag, None, None]:
+    """Fetch article titles and URLs submitted to a Zenn contest.
+
+    Zenn provides no RSS feed for contests, so this fetcher depends on the
+    undocumented JSON API which Zenn may change without notice.
+
+    Args:
+        url: Zenn contest URL (e.g., https://zenn.dev/contests/example-2026)
+
+    Yields:
+        TitleTag dictionaries containing title and url
+    """
+    contest_slug = _extract_contest_slug(url)
+
+    page = 1
+    while page:
+        response = httpx.get(
+            ZENN_ARTICLES_API_URL,
+            params={
+                "contest_slug": contest_slug,
+                "order": "latest",
+                "page": page,
+            },
+        )
+        response.raise_for_status()
+
+        paginated_articles = response.json()
+
+        for article in paginated_articles["articles"]:
+            yield {
+                "title": article["title"],
+                "url": urljoin(ZENN_ORIGIN, article["path"]),
+            }
+
+        page = paginated_articles["next_page"]
+
+
+def _extract_contest_slug(url: str) -> str:
+    return urlparse(url).path.removeprefix("/contests/").split("/")[0]

--- a/tests/fetch/test_core.py
+++ b/tests/fetch/test_core.py
@@ -20,6 +20,7 @@ from recent_state_summarizer.fetch.qiita_official_event import (
 )
 from recent_state_summarizer.fetch.qiita_rss import fetch_qiita_rss
 from recent_state_summarizer.fetch.registry import get_fetcher
+from recent_state_summarizer.fetch.zenn_contest import fetch_zenn_contest
 from recent_state_summarizer.fetch.zenn_rss import fetch_zenn_rss
 
 
@@ -95,6 +96,12 @@ class TestGetFetcher:
     def test_zenn_rss(self):
         url = "https://zenn.dev/ftnext/feed?all=1"
         assert get_fetcher(url) == fetch_zenn_rss
+
+    def test_zenn_contest(self):
+        url = (
+            "https://zenn.dev/contests/splunk-opentelemetry-2026?tab=articles"
+        )
+        assert get_fetcher(url) == fetch_zenn_contest
 
     def test_github_changelog(self):
         url = "https://github.blog/changelog/feed/"

--- a/tests/fetch/test_core.py
+++ b/tests/fetch/test_core.py
@@ -103,6 +103,11 @@ class TestGetFetcher:
         )
         assert get_fetcher(url) == fetch_zenn_contest
 
+    def test_zenn_contest_without_slug_raises(self):
+        url = "https://zenn.dev/contests/"
+        with pytest.raises(ValueError, match="Unsupported URL"):
+            get_fetcher(url)
+
     def test_github_changelog(self):
         url = "https://github.blog/changelog/feed/"
         assert get_fetcher(url) == fetch_github_changelog

--- a/tests/fetch/test_zenn_contest.py
+++ b/tests/fetch/test_zenn_contest.py
@@ -1,0 +1,105 @@
+import json
+
+import httpx
+import respx
+
+from recent_state_summarizer.fetch.cli import _main
+
+CONTEST_URL = "https://zenn.dev/contests/splunk-opentelemetry-2026"
+ARTICLES_API_URL = "https://zenn.dev/api/articles"
+CONTEST_SLUG = "splunk-opentelemetry-2026"
+
+
+def build_api_response(articles, next_page):
+    return json.dumps(
+        {
+            "articles": [
+                {"title": title, "path": path} for title, path in articles
+            ],
+            "next_page": next_page,
+            "total_count": None,
+        }
+    )
+
+
+def mock_api_page(page, articles, next_page):
+    respx.get(
+        ARTICLES_API_URL,
+        params={
+            "contest_slug": CONTEST_SLUG,
+            "order": "latest",
+            "page": page,
+        },
+    ).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            text=build_api_response(articles, next_page),
+            headers={"content-type": "application/json"},
+        )
+    )
+
+
+@respx.mock
+def test_fetch_zenn_contest_as_bullet_list(tmp_path):
+    mock_api_page(
+        1,
+        [("OpenTelemetry入門", "/user1/articles/abc123")],
+        next_page=None,
+    )
+
+    _main(CONTEST_URL, tmp_path / "titles.txt", save_as_title_list=True)
+
+    expected = "- OpenTelemetry入門"
+    assert (tmp_path / "titles.txt").read_text(encoding="utf8") == expected
+
+
+@respx.mock
+def test_fetch_zenn_contest_as_json(tmp_path):
+    mock_api_page(
+        1,
+        [("OpenTelemetry入門", "/user1/articles/abc123")],
+        next_page=None,
+    )
+
+    _main(CONTEST_URL, tmp_path / "titles.jsonl", save_as_title_list=False)
+
+    expected = (
+        '{"title": "OpenTelemetry入門", '
+        '"url": "https://zenn.dev/user1/articles/abc123"}'
+    )
+    assert (tmp_path / "titles.jsonl").read_text(encoding="utf8") == expected
+
+
+@respx.mock
+def test_fetch_zenn_contest_follows_pagination(tmp_path):
+    mock_api_page(
+        1, [("1ページ目の記事", "/user1/articles/abc123")], next_page=2
+    )
+    mock_api_page(
+        2, [("2ページ目の記事", "/user2/articles/def456")], next_page=None
+    )
+
+    _main(CONTEST_URL, tmp_path / "titles.txt", save_as_title_list=True)
+
+    expected = """\
+- 1ページ目の記事
+- 2ページ目の記事"""
+    assert (tmp_path / "titles.txt").read_text(encoding="utf8") == expected
+
+
+@respx.mock
+def test_fetch_zenn_contest_with_tab_query(tmp_path):
+    mock_api_page(
+        1,
+        [("OpenTelemetry入門", "/user1/articles/abc123")],
+        next_page=None,
+    )
+
+    _main(
+        f"{CONTEST_URL}?tab=articles",
+        tmp_path / "titles.txt",
+        save_as_title_list=True,
+    )
+
+    expected = "- OpenTelemetry入門"
+    assert (tmp_path / "titles.txt").read_text(encoding="utf8") == expected


### PR DESCRIPTION
## Summary
Zenn のコンテストページ（例: `https://zenn.dev/contests/splunk-opentelemetry-2026?tab=articles`）の応募記事を取得する fetcher を **experimental** として追加します。

Zenn はコンテストページ用の RSS を提供しておらず、記事一覧はサーバーサイドレンダリングされた HTML にも含まれていない（`__NEXT_DATA__` には `contest` と `entryCount` のみ）ため、クライアントが叩いている JSON API を利用します。

## Implementation
- `recent_state_summarizer/fetch/zenn_contest.py`
  - matcher: netloc が `zenn.dev` かつ path が `/contests/` 始まり（`?tab=articles` などのクエリは無視）
  - `https://zenn.dev/api/articles?contest_slug={slug}&order=latest&page=N` を呼び、`next_page` が `null` になるまでページネーションを追跡（`qiita_official_event.py` と同じ形）
  - レスポンスの `path`（例 `/user/articles/abc123`）を `https://zenn.dev` と結合して URL 化
- `recent_state_summarizer/fetch/__init__.py`: 登録用の import を1行追加
- `CLAUDE.md`: サポート一覧と fetcher 実装一覧に追記

## ⚠️ experimental である理由
`/api/articles` は Zenn が公開ドキュメントで仕様を示していない API です。Qiita API v2 のような後方互換の保証がなく、Zenn 側の変更で壊れる可能性があります。ヘルプに表示される fetcher 名も `Zenn Contest (experimental)` としています。

## Test
- `tests/fetch/test_zenn_contest.py`: respx で API をモックし、bullet list / JSON Lines 出力、`next_page` によるページネーション追跡、`?tab=articles` 付き URL を検証
- `tests/fetch/test_core.py`: `get_fetcher()` がコンテスト URL で `fetch_zenn_contest` を返すことを検証
- `python -m pytest -q` → 55 passed
- 実 URL での動作確認: 78件取得（コンテストページの `entryCount` と一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)