### PR TITLE
feat: Fetch GitHub Changelog entries from the recent 30 days

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Qiita Official Event (公式イベント)
 - Zenn RSS (user feeds)
 - Zenn Contest (experimental)
+- GitHub Changelog
 
 The main CLI command is `omae-douyo` which fetches titles and generates a summary in Japanese.
 
@@ -120,6 +121,7 @@ The fetcher system uses a registry pattern where each fetcher self-registers:
    - `qiita_official_event.py`: Uses httpx + BeautifulSoup to extract JSON data from Qiita official event pages, following `?page=N` pagination via `pageData.nextPage`
    - `zenn_rss.py`: Parses RSS feeds with feedparser (user feeds, `https://zenn.dev/{username}/feed?all=1`)
    - `zenn_contest.py`: Uses httpx to call the undocumented `https://zenn.dev/api/articles?contest_slug={slug}` JSON API, following pagination via `next_page` (experimental: Zenn publishes neither a contest RSS feed nor this API's specification)
+   - `github_changelog.py`: Parses RSS feeds with feedparser, walking `?paged=N` pagination until entries fall outside the `RECENT_DAYS` (30 day) window. The feed exposes no `rel="next"` link and ignores per-page size parameters, so the page number is incremented directly and the walk stops on the first entry older than the cutoff, an empty page, or a 404 (past the last page). Redirects are followed because `?paged=1` and the URL without a trailing slash are answered with 301 to their canonical form.
 
 All fetchers yield `TitleTag` TypedDict objects with `title` and `url` keys.
 

--- a/recent_state_summarizer/fetch/github_changelog.py
+++ b/recent_state_summarizer/fetch/github_changelog.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
 
 import feedparser
@@ -6,6 +7,8 @@ import httpx
 
 from recent_state_summarizer.fetch.registry import register_fetcher
 from recent_state_summarizer.fetch.types import TitleTag
+
+RECENT_DAYS = 30
 
 
 def _match_github_changelog(url: str) -> bool:
@@ -16,12 +19,49 @@ def _match_github_changelog(url: str) -> bool:
     )
 
 
+def _recent_cutoff() -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=RECENT_DAYS)
+
+
+def _published_at(entry) -> datetime:
+    return datetime(*entry.published_parsed[:6], tzinfo=timezone.utc)
+
+
 @register_fetcher(name="GitHub Changelog", matcher=_match_github_changelog)
 def fetch_github_changelog(url: str) -> Generator[TitleTag, None, None]:
-    response = httpx.get(url)
-    response.raise_for_status()
+    """Fetch changelog entries published within the recent days.
 
-    feed = feedparser.parse(response.content)
+    The feed returns 10 entries per page and ignores per-page size
+    parameters, so entries older than the cutoff are reached by walking
+    `?paged=N` until the cutoff, an empty page or a 404 response.
 
-    for entry in feed.entries:
-        yield {"title": entry.title, "url": entry.link}
+    Redirects are followed because `?paged=1` and the URL without a
+    trailing slash are answered with 301 to their canonical form.
+
+    Args:
+        url: GitHub Changelog feed URL (https://github.blog/changelog/feed/)
+
+    Yields:
+        TitleTag dictionaries containing title and url
+    """
+    cutoff = _recent_cutoff()
+
+    page = 1
+    while True:
+        response = httpx.get(
+            url, params={"paged": page}, follow_redirects=True
+        )
+        if response.status_code == httpx.codes.NOT_FOUND:
+            return
+        response.raise_for_status()
+
+        feed = feedparser.parse(response.content)
+        if not feed.entries:
+            return
+
+        for entry in feed.entries:
+            if _published_at(entry) < cutoff:
+                return
+            yield {"title": entry.title, "url": entry.link}
+
+        page += 1

--- a/tests/fetch/test_github_changelog.py
+++ b/tests/fetch/test_github_changelog.py
@@ -1,15 +1,32 @@
+from datetime import datetime, timezone
+
 import httpx
+import pytest
 import respx
 
+from recent_state_summarizer.fetch import github_changelog
 from recent_state_summarizer.fetch.github_changelog import (
     fetch_github_changelog,
 )
 
+FEED_URL = "https://github.blog/changelog/feed/"
+CUTOFF = datetime(2026, 7, 4, tzinfo=timezone.utc)
 
-class TestGitHubChangelog:
-    @respx.mock
-    def test_fetch_github_changelog(self):
-        rss_feed = """\
+
+def build_item(title, link, published):
+    return f"""\
+  <item>
+    <title>{title}</title>
+    <link>{link}</link>
+    <pubDate>{published}</pubDate>
+    <dc:creator><![CDATA[Author]]></dc:creator>
+    <description><![CDATA[<p>Description</p>]]></description>
+  </item>"""
+
+
+def build_rss_feed(items):
+    entries = "\n".join(build_item(*item) for item in items)
+    return f"""\
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0"
   xmlns:content="http://purl.org/rss/1.0/modules/content/"
@@ -20,33 +37,53 @@ class TestGitHubChangelog:
   <title>The GitHub Blog: GitHub Changelog</title>
   <link>https://github.blog/changelog</link>
   <description>Subscribe to Changelog</description>
-  <item>
-    <title>Changelog entry 1</title>
-    <link>https://github.blog/changelog/2026-07-01-entry-1/</link>
-    <dc:creator><![CDATA[Author 1]]></dc:creator>
-    <description><![CDATA[<p>Description 1</p>]]></description>
-    <content:encoded><![CDATA[<p>Content 1</p>]]></content:encoded>
-  </item>
-  <item>
-    <title>Changelog entry 2</title>
-    <link>https://github.blog/changelog/2026-07-02-entry-2/</link>
-    <dc:creator><![CDATA[Author 2]]></dc:creator>
-    <description><![CDATA[<p>Description 2</p>]]></description>
-    <content:encoded><![CDATA[<p>Content 2</p>]]></content:encoded>
-  </item>
+{entries}
 </channel>
 </rss>"""
-        respx.get("https://github.blog/changelog/feed/").mock(
-            return_value=httpx.Response(
-                status_code=200,
-                content=rss_feed.encode("utf-8"),
-                headers={"content-type": "application/rss+xml"},
-            )
-        )
 
-        result = list(
-            fetch_github_changelog("https://github.blog/changelog/feed/")
+
+def mock_feed_page(page, items):
+    return respx.get(FEED_URL, params={"paged": page}).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            content=build_rss_feed(items).encode("utf-8"),
+            headers={"content-type": "application/rss+xml"},
         )
+    )
+
+
+def mock_feed_page_not_found(page):
+    return respx.get(FEED_URL, params={"paged": page}).mock(
+        return_value=httpx.Response(status_code=404)
+    )
+
+
+@pytest.fixture
+def fixed_cutoff(monkeypatch):
+    monkeypatch.setattr(github_changelog, "_recent_cutoff", lambda: CUTOFF)
+
+
+class TestGitHubChangelog:
+    @respx.mock
+    def test_fetch_github_changelog(self, fixed_cutoff):
+        mock_feed_page(
+            1,
+            [
+                (
+                    "Changelog entry 1",
+                    "https://github.blog/changelog/2026-07-01-entry-1/",
+                    "Wed, 29 Jul 2026 14:01:07 +0000",
+                ),
+                (
+                    "Changelog entry 2",
+                    "https://github.blog/changelog/2026-07-02-entry-2/",
+                    "Mon, 27 Jul 2026 17:00:35 +0000",
+                ),
+            ],
+        )
+        mock_feed_page_not_found(2)
+
+        result = list(fetch_github_changelog(FEED_URL))
 
         assert len(result) == 2
         assert result[0]["title"] == "Changelog entry 1"
@@ -59,3 +96,121 @@ class TestGitHubChangelog:
             result[1]["url"]
             == "https://github.blog/changelog/2026-07-02-entry-2/"
         )
+
+    @respx.mock
+    def test_follows_pagination(self, fixed_cutoff):
+        mock_feed_page(
+            1,
+            [
+                (
+                    "1ページ目の記事",
+                    "https://github.blog/changelog/2026-07-29-page-1/",
+                    "Wed, 29 Jul 2026 14:01:07 +0000",
+                )
+            ],
+        )
+        mock_feed_page(
+            2,
+            [
+                (
+                    "2ページ目の記事",
+                    "https://github.blog/changelog/2026-07-20-page-2/",
+                    "Mon, 20 Jul 2026 18:24:14 +0000",
+                )
+            ],
+        )
+        mock_feed_page_not_found(3)
+
+        result = list(fetch_github_changelog(FEED_URL))
+
+        assert [title_tag["title"] for title_tag in result] == [
+            "1ページ目の記事",
+            "2ページ目の記事",
+        ]
+
+    @respx.mock
+    def test_stops_at_entry_older_than_cutoff(self, fixed_cutoff):
+        mock_feed_page(
+            1,
+            [
+                (
+                    "直近の記事",
+                    "https://github.blog/changelog/2026-07-29-recent/",
+                    "Wed, 29 Jul 2026 14:01:07 +0000",
+                )
+            ],
+        )
+        mock_feed_page(
+            2,
+            [
+                (
+                    "カットオフ内の記事",
+                    "https://github.blog/changelog/2026-07-07-in-window/",
+                    "Tue, 07 Jul 2026 17:09:29 +0000",
+                ),
+                (
+                    "カットオフより古い記事",
+                    "https://github.blog/changelog/2026-07-02-too-old/",
+                    "Thu, 02 Jul 2026 08:17:17 +0000",
+                ),
+            ],
+        )
+        third_page = mock_feed_page(3, [])
+
+        result = list(fetch_github_changelog(FEED_URL))
+
+        assert [title_tag["title"] for title_tag in result] == [
+            "直近の記事",
+            "カットオフ内の記事",
+        ]
+        assert not third_page.called
+
+    @respx.mock
+    def test_stops_at_empty_page(self, fixed_cutoff):
+        mock_feed_page(
+            1,
+            [
+                (
+                    "直近の記事",
+                    "https://github.blog/changelog/2026-07-29-recent/",
+                    "Wed, 29 Jul 2026 14:01:07 +0000",
+                )
+            ],
+        )
+        mock_feed_page(2, [])
+        third_page = mock_feed_page(3, [])
+
+        result = list(fetch_github_changelog(FEED_URL))
+
+        assert [title_tag["title"] for title_tag in result] == ["直近の記事"]
+        assert not third_page.called
+
+    @respx.mock
+    def test_follows_redirect_to_canonical_url(self, fixed_cutoff):
+        respx.get(FEED_URL, params={"paged": 1}).mock(
+            return_value=httpx.Response(
+                status_code=301, headers={"location": FEED_URL}
+            )
+        )
+        mock_feed_page_not_found(2)
+        respx.get(FEED_URL).mock(
+            return_value=httpx.Response(
+                status_code=200,
+                content=build_rss_feed(
+                    [
+                        (
+                            "リダイレクト先の記事",
+                            "https://github.blog/changelog/2026-07-29-entry/",
+                            "Wed, 29 Jul 2026 14:01:07 +0000",
+                        )
+                    ]
+                ).encode("utf-8"),
+                headers={"content-type": "application/rss+xml"},
+            )
+        )
+
+        result = list(fetch_github_changelog(FEED_URL))
+
+        assert [title_tag["title"] for title_tag in result] == [
+            "リダイレクト先の記事"
+        ]


### PR DESCRIPTION
## 背景

```
omae-douyo fetch https://github.blog/changelog/feed/ gh-releases.jsonl
```

これが **10件しか取れない**。`fetch_github_changelog` が `httpx.get(url)` を1回叩くだけで、WordPress の RSS 既定件数 (`posts_per_rss` = 10) をそのまま返していたため。

実フィードを叩いて調べた結果:

| 確認項目 | 結果 |
|---|---|
| `?paged=N` | **効く**。ページごとに別の10件が返る |
| `?posts_per_page=30` | **無視される** (10件のまま) → 1ページの件数は増やせない |
| `<atom:link rel="next">` | **無い** → `zenn_contest` / `qiita_official_event` のような next シグナルは使えない |
| 最終ページ超過 | **HTTP 404** |
| `?paged=1` | **301** → `https://github.blog/changelog/feed/` |
| 末尾スラッシュ無しURL | **301** → 末尾スラッシュ有りへ (全ページで) |

件数を増やす手段は `?paged=N` のページ送りのみ。

## 変更内容

`fetch_github_changelog` を「`?paged=N` を辿り、公開日が直近30日を下回ったら止まる」遅延ジェネレータにした。

終端条件は3つ:
1. **カットオフ到達** — エントリは新しい順なので、最初に古いものを見た時点で停止 (通常ケース)
2. **404** — アーカイブ末尾。フィード全体が30日に満たない場合の保険
3. **空ページ** — 200 だが item ゼロのケースの保険

`follow_redirects=True` を付けている。`?paged=1` の 301 に加え、matcher が `.rstrip("/")` で受け付けている**末尾スラッシュ無しURL も全ページで 301 する**ため、こちらは既存の潜在バグの修正も兼ねる。

方針として**共通化はせず github.blog のケースだけに閉じた**。`registry.py` の `Fetcher` 型契約、`cli.py`、`__main__.py`、他10個の fetcher はいずれも変更していない。期間は `RECENT_DAYS = 30` のモジュール定数で、CLI から変更する手段は設けていない。

## 動作確認

実フィードでの end-to-end (2026-08-03 時点):

```
$ omae-douyo fetch https://github.blog/changelog/feed/ gh-releases.jsonl
entries: 74        (重複 0 件)
newest : 2026-07-31 Gemini 2.5 Pro and Gemini 3 Flash deprecated
oldest : 2026-07-07 Copilot Billing Preview app will be retired on August 3
```

10件 → 74件。8リクエスト・約10秒。カットオフ (2026-07-04) を跨ぐ8ページ目の途中で正しく停止している。末尾スラッシュ無しURLでも同じ74件が取れることを確認した。

## テスト

`tests/fetch/test_github_changelog.py` を書き換え。既存テストはそのままでは通らなかった:
- フィクスチャの `<item>` に `<pubDate>` が無く `published_parsed` が引けない
- params 無しで登録した respx モックは `?paged=2` にもマッチするため、全ページが同じ2件を返し続けて終端しない

そのため `tests/fetch/test_zenn_contest.py` と同じ `respx.get(URL, params={"paged": N})` の書き方に揃えた。`freezegun` / `time-machine` は依存に無いので、カットオフは `_recent_cutoff` を `monkeypatch` で固定している。

追加したケース: ページ送り / カットオフで停止 (次ページを**取りに行かない**ことを `route.called` で確認) / 空ページ終端 / 301 追従。301 追従のテストは `follow_redirects=True` を外すと落ちることを確認済み。

```
60 passed
```

`black -l 79` / `isort --profile black -l 79` 適用済み。CLAUDE.md にも GitHub Changelog の項を追記した (元々記載が無かった)。

## 副作用

- `omae-douyo <feed>` (`run` = 要約まで実行) も同じ fetcher を通るため、要約対象が 10件 → 約74件に増える
- 1回の実行で HTTP リクエストが 1回 → 約8回になる

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6H7yfPjvDKSgzoLRuU5WT)_