### PR TITLE
GitHub Changelog の取得中に1ページごとの進行状況をログ出力する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,13 +121,14 @@ The fetcher system uses a registry pattern where each fetcher self-registers:
    - `qiita_official_event.py`: Uses httpx + BeautifulSoup to extract JSON data from Qiita official event pages, following `?page=N` pagination via `pageData.nextPage`
    - `zenn_rss.py`: Parses RSS feeds with feedparser (user feeds, `https://zenn.dev/{username}/feed?all=1`)
    - `zenn_contest.py`: Uses httpx to call the undocumented `https://zenn.dev/api/articles?contest_slug={slug}` JSON API, following pagination via `next_page` (experimental: Zenn publishes neither a contest RSS feed nor this API's specification)
-   - `github_changelog.py`: Parses RSS feeds with feedparser, walking `?paged=N` pagination until entries fall outside the `RECENT_DAYS` (30 day) window. The feed exposes no `rel="next"` link and ignores per-page size parameters, so the page number is incremented directly and the walk stops on the first entry older than the cutoff, an empty page, or a 404 (past the last page). Redirects are followed because `?paged=1` and the URL without a trailing slash are answered with 301 to their canonical form.
+   - `github_changelog.py`: Parses RSS feeds with feedparser, walking `?paged=N` pagination until entries fall outside the `RECENT_DAYS` (30 day) window. The feed exposes no `rel="next"` link and ignores per-page size parameters, so the page number is incremented directly and the walk stops on the first entry older than the cutoff, an empty page, or a 404 (past the last page). Redirects are followed because `?paged=1` and the URL without a trailing slash are answered with 301 to their canonical form. Since the whole walk happens before anything is written, progress is reported with `logger.info()` once per page before each request (see `configure_logging()` below).
 
 All fetchers yield `TitleTag` TypedDict objects with `title` and `url` keys.
 
 3. **CLI Interface** (`fetch/cli.py`):
    - `_main(url, save_path, save_as_title_list)`: Core fetch logic that gets the appropriate fetcher, fetches titles, and saves to file
    - `build_parser(add_help)`: Builds argparse parser with dynamic help message using `get_registered_names()`
+   - `configure_logging()`: Sets the `recent_state_summarizer` logger to INFO so fetcher progress reaches stderr, leaving the root logger at WARNING so third-party INFO logs (such as httpx request lines) stay silent. Called from both `cli()` and `__main__.py:main()`; stderr keeps progress out of the saved file and out of the summary printed to stdout by `omae-douyo run`.
    - `cli()`: Entry point for `python -m recent_state_summarizer.fetch`
    - Called by `__main__.py:fetch_cli()` when using `omae-douyo fetch` subcommand
 

--- a/recent_state_summarizer/__main__.py
+++ b/recent_state_summarizer/__main__.py
@@ -7,6 +7,9 @@ from recent_state_summarizer.fetch.cli import _main as fetch_main
 from recent_state_summarizer.fetch.cli import (
     build_parser as build_fetch_parser,
 )
+from recent_state_summarizer.fetch.cli import (
+    configure_logging,
+)
 from recent_state_summarizer.summarize import summarize_titles
 
 
@@ -77,6 +80,7 @@ def normalize_argv() -> list[str]:
 
 
 def main():
+    configure_logging()
     parser = build_parser()
     argv = normalize_argv()
     args = parser.parse_args(argv)

--- a/recent_state_summarizer/fetch/cli.py
+++ b/recent_state_summarizer/fetch/cli.py
@@ -78,7 +78,13 @@ def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
     return parser
 
 
+def configure_logging() -> None:
+    logging.basicConfig(format="%(message)s")
+    logging.getLogger("recent_state_summarizer").setLevel(logging.INFO)
+
+
 def cli():
+    configure_logging()
     parser = build_parser()
     args = parser.parse_args()
 

--- a/recent_state_summarizer/fetch/github_changelog.py
+++ b/recent_state_summarizer/fetch/github_changelog.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
@@ -7,6 +8,8 @@ import httpx
 
 from recent_state_summarizer.fetch.registry import register_fetcher
 from recent_state_summarizer.fetch.types import TitleTag
+
+logger = logging.getLogger(__name__)
 
 RECENT_DAYS = 30
 
@@ -48,6 +51,7 @@ def fetch_github_changelog(url: str) -> Generator[TitleTag, None, None]:
 
     page = 1
     while True:
+        logger.info("Fetching page %s of %s", page, url)
         response = httpx.get(
             url, params={"paged": page}, follow_redirects=True
         )

--- a/tests/fetch/test_github_changelog.py
+++ b/tests/fetch/test_github_changelog.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 
 import httpx
@@ -126,6 +127,43 @@ class TestGitHubChangelog:
         assert [title_tag["title"] for title_tag in result] == [
             "1ページ目の記事",
             "2ページ目の記事",
+        ]
+
+    @respx.mock
+    def test_logs_progress_per_page(self, fixed_cutoff, caplog):
+        caplog.set_level(logging.INFO)
+        mock_feed_page(
+            1,
+            [
+                (
+                    "1ページ目の記事",
+                    "https://github.blog/changelog/2026-07-29-page-1/",
+                    "Wed, 29 Jul 2026 14:01:07 +0000",
+                )
+            ],
+        )
+        mock_feed_page(
+            2,
+            [
+                (
+                    "2ページ目の記事",
+                    "https://github.blog/changelog/2026-07-20-page-2/",
+                    "Mon, 20 Jul 2026 18:24:14 +0000",
+                )
+            ],
+        )
+        mock_feed_page_not_found(3)
+
+        list(fetch_github_changelog(FEED_URL))
+
+        assert [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == github_changelog.__name__
+        ] == [
+            f"Fetching page 1 of {FEED_URL}",
+            f"Fetching page 2 of {FEED_URL}",
+            f"Fetching page 3 of {FEED_URL}",
         ]
 
     @respx.mock


### PR DESCRIPTION
## 背景

`omae-douyo fetch https://github.blog/changelog/feed/` は `?paged=N` を1ページずつ辿りますが、このループは完全に無言でした。さらに `fetch/cli.py:_main()` はジェネレーターを `"\n".join(...)` で消費するまで遅延するため、全ページのネットワークI/Oが終わるまでファイルにも何も書かれません。ユーザーから見ると「固まっている」ように見えていました。

## 変更内容

### `fetch/github_changelog.py`
ページングループの**リクエスト前**に、1ページ1行のログを出します。

```python
    page = 1
    while True:
        logger.info("Fetching page %s of %s", page, url)
        response = httpx.get(...)
```

既存の終了条件（404 / 空ページ / cutoff より古いエントリー）とジェネレーターの挙動は変えていません。

### `fetch/cli.py`
`logging.basicConfig` を呼ばないとログがどこにも出ないため、エントリーポイント用のヘルパーを追加しました。

```python
def configure_logging() -> None:
    logging.basicConfig(format="%(message)s")
    logging.getLogger("recent_state_summarizer").setLevel(logging.INFO)
```

- ルートロガーは WARNING のままにし、パッケージのロガーだけ INFO に上げています。こうしないと httpx が `HTTP Request: GET ... "HTTP/1.1 200 OK"` を INFO で出すため、進行状況が埋もれます。
- `basicConfig` の既定ストリームは **stderr** なので、`fetch` の保存ファイルにも `run` の要約 stdout にも混ざりません。
- `format="%(message)s"` で既定の `INFO:recent_state_summarizer.fetch...:` プレフィックスを落としています。

`cli()`（`python -m recent_state_summarizer.fetch`）と `__main__.py:main()` の両方から呼ぶので、`omae-douyo run` でも進行状況が見えます。

## 実行例

```console
$ omae-douyo fetch https://github.blog/changelog/feed/ articles.jsonl
Fetching page 1 of https://github.blog/changelog/feed/
Fetching page 2 of https://github.blog/changelog/feed/
Fetching page 3 of https://github.blog/changelog/feed/
```

## テスト

`tests/fetch/test_github_changelog.py` に `test_logs_progress_per_page` を追加しました。既存の `fixed_cutoff` フィクスチャと `mock_feed_page` / `mock_feed_page_not_found` ヘルパーを再利用し、`caplog` でページ番号を含むログが出ることを確認しています（httpx のログと混ざらないよう、ロガー名でフィルタしています）。

既存のテストは変更なしで通ります。

```console
$ python -m pytest -q
61 passed
```

`uvx black -l 79 .` と `uvx isort --profile black -l 79 .` を適用済みです。

## 補足

「何日取得するかをコマンドライン引数から変更できるようにしたい」（`--days` オプション）は別のPRとして分けています。本PRでは `RECENT_DAYS = 30` は据え置きです。

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRjfZbafV7nnnRSnceJdLg)_