### PR TITLE
feat: Add `omae-douyo fetch github-blog` sub-command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,10 @@ omae-douyo fetch https://qiita.com/ftnext/feed.atom articles.jsonl
 
 # Fetch only (save as title list)
 omae-douyo fetch https://nikkie-ftnext.hatenablog.com/archive/2023/4 titles.txt --as-title-list
+
+# Fetch the GitHub Changelog without specifying its feed URL
+omae-douyo fetch github-blog articles.jsonl
+omae-douyo fetch github-blog articles.jsonl --days 45
 ```
 
 ### Development Sub-commands
@@ -121,13 +125,15 @@ The fetcher system uses a registry pattern where each fetcher self-registers:
    - `qiita_official_event.py`: Uses httpx + BeautifulSoup to extract JSON data from Qiita official event pages, following `?page=N` pagination via `pageData.nextPage`
    - `zenn_rss.py`: Parses RSS feeds with feedparser (user feeds, `https://zenn.dev/{username}/feed?all=1`)
    - `zenn_contest.py`: Uses httpx to call the undocumented `https://zenn.dev/api/articles?contest_slug={slug}` JSON API, following pagination via `next_page` (experimental: Zenn publishes neither a contest RSS feed nor this API's specification)
-   - `github_changelog.py`: Parses RSS feeds with feedparser, walking `?paged=N` pagination until entries fall outside the `RECENT_DAYS` (30 day) window. The feed exposes no `rel="next"` link and ignores per-page size parameters, so the page number is incremented directly and the walk stops on the first entry older than the cutoff, an empty page, or a 404 (past the last page). Redirects are followed because `?paged=1` and the URL without a trailing slash are answered with 301 to their canonical form. Since the whole walk happens before anything is written, progress is reported with `logger.info()` once per page before each request (see `configure_logging()` below).
+   - `github_changelog.py`: Parses RSS feeds with feedparser, walking `?paged=N` pagination until entries fall outside the `days` window (`fetch_github_changelog(url, *, days=RECENT_DAYS)`, defaulting to the `RECENT_DAYS` 30 day window; the `github-blog` sub-command exposes it as `--days`). `FEED_URL` holds the canonical feed URL so the CLI can offer it as a default. The feed exposes no `rel="next"` link and ignores per-page size parameters, so the page number is incremented directly and the walk stops on the first entry older than the cutoff, an empty page, or a 404 (past the last page). Redirects are followed because `?paged=1` and the URL without a trailing slash are answered with 301 to their canonical form. Since the whole walk happens before anything is written, progress is reported with `logger.info()` once per page before each request (see `configure_logging()` below).
 
 All fetchers yield `TitleTag` TypedDict objects with `title` and `url` keys.
 
 3. **CLI Interface** (`fetch/cli.py`):
-   - `_main(url, save_path, save_as_title_list)`: Core fetch logic that gets the appropriate fetcher, fetches titles, and saves to file
-   - `build_parser(add_help)`: Builds argparse parser with dynamic help message using `get_registered_names()`
+   - `_main(url, save_path, save_as_title_list, days=None)`: Core fetch logic that gets the appropriate fetcher, fetches titles, and saves to file. `days` is forwarded to the fetcher as a keyword argument only when it is not `None`, so fetchers that take no period keep their single-argument signature
+   - `build_parser(add_help)`: Builds argparse parser with dynamic help message using `get_registered_names()`, for the `<url> <save_path>` form
+   - `build_github_blog_parser(add_help)`: Builds the parser for the `github-blog` sub-command (`<save_path>` plus `--days`, with `set_defaults(url=FEED_URL)` supplying the feed URL)
+   - `select_parser_builder(fetch_argv)`: Picks between the two builders by looking at the first argument after `fetch`. argparse cannot have a sub-parser and a preceding positional `url` in the same parser, so the parser is chosen from argv *before* parsing rather than expressed as nested sub-parsers. This keeps `omae-douyo fetch <url> <save_path>` unchanged and keeps `--days` out of its help
    - `configure_logging()`: Sets the `recent_state_summarizer` logger to INFO so fetcher progress reaches stderr, leaving the root logger at WARNING so third-party INFO logs (such as httpx request lines) stay silent. Called from both `cli()` and `__main__.py:main()`; stderr keeps progress out of the saved file and out of the summary printed to stdout by `omae-douyo run`.
    - `cli()`: Entry point for `python -m recent_state_summarizer.fetch`
    - Called by `__main__.py:fetch_cli()` when using `omae-douyo fetch` subcommand
@@ -168,6 +174,7 @@ The fetcher registry enables dynamic help message generation. When creating subp
 
 ```python
 # __main__.py
+build_fetch_parser = select_parser_builder(_fetch_argv(argv))
 fetch_parser_template = build_fetch_parser(add_help=False)
 fetch_parser = subparsers.add_parser(
     "fetch",
@@ -177,7 +184,9 @@ fetch_parser = subparsers.add_parser(
 )
 ```
 
-The `build_fetch_parser()` in `fetch/__init__.py` uses `get_registered_names()` to dynamically generate the fetcher list, ensuring new fetchers automatically appear in help without manual updates.
+The `build_parser()` in `fetch/cli.py` uses `get_registered_names()` to dynamically generate the fetcher list, ensuring new fetchers automatically appear in help without manual updates.
+
+Because the template depends on argv (see `select_parser_builder()` above), `build_parser()` in `__main__.py` takes the normalized argv and `main()` calls `normalize_argv()` before building the parser. `parents` also carries over `set_defaults()` values, which is how the `github-blog` sub-command supplies `args.url` without a `url` positional.
 
 ### Summarization
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ $ omae-douyo fetch https://nikkie-ftnext.hatenablog.com/archive/2023/4 articles.
 $ omae-douyo fetch https://nikkie-ftnext.hatenablog.com/archive/2023/4 titles.txt --as-title-list
 ```
 
+#### GitHub Changelog
+
+The `github-blog` sub-command fetches the GitHub Changelog without specifying its feed URL:
+
+```
+$ omae-douyo fetch github-blog articles.jsonl
+
+# Change the period to fetch entries from (default: 30 days)
+$ omae-douyo fetch github-blog articles.jsonl --days 45
+```
+
 ## Development
 
 ### Sub commands

--- a/recent_state_summarizer/__main__.py
+++ b/recent_state_summarizer/__main__.py
@@ -5,15 +5,19 @@ from textwrap import dedent
 
 from recent_state_summarizer.fetch.cli import _main as fetch_main
 from recent_state_summarizer.fetch.cli import (
-    build_parser as build_fetch_parser,
-)
-from recent_state_summarizer.fetch.cli import (
     configure_logging,
+    select_parser_builder,
 )
 from recent_state_summarizer.summarize import summarize_titles
 
 
-def build_parser():
+def _fetch_argv(argv: list[str] | None) -> list[str]:
+    if argv and argv[0] == "fetch":
+        return argv[1:]
+    return []
+
+
+def build_parser(argv: list[str] | None = None):
     help_message = """
     Summarize blog article titles with the OpenAI API.
 
@@ -37,6 +41,7 @@ def build_parser():
     run_parser.add_argument("url", help="URL of archive page")
     run_parser.set_defaults(func=run_cli)
 
+    build_fetch_parser = select_parser_builder(_fetch_argv(argv))
     fetch_parser_template = build_fetch_parser(add_help=False)
     fetch_parser = subparsers.add_parser(
         "fetch",
@@ -60,7 +65,12 @@ def run_cli(args):
 
 
 def fetch_cli(args):
-    fetch_main(args.url, args.save_path, save_as_title_list=args.as_title_list)
+    fetch_main(
+        args.url,
+        args.save_path,
+        save_as_title_list=args.as_title_list,
+        days=args.days,
+    )
 
 
 def normalize_argv() -> list[str]:
@@ -81,7 +91,7 @@ def normalize_argv() -> list[str]:
 
 def main():
     configure_logging()
-    parser = build_parser()
     argv = normalize_argv()
+    parser = build_parser(argv)
     args = parser.parse_args(argv)
     args.func(args)

--- a/recent_state_summarizer/fetch/cli.py
+++ b/recent_state_summarizer/fetch/cli.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import sys
 import textwrap
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 
+from recent_state_summarizer.fetch.github_changelog import (
+    FEED_URL as GITHUB_BLOG_FEED_URL,
+)
+from recent_state_summarizer.fetch.github_changelog import (
+    RECENT_DAYS,
+)
 from recent_state_summarizer.fetch.registry import (
     get_fetcher,
     get_registered_names,
@@ -15,12 +22,19 @@ from recent_state_summarizer.fetch.types import TitleTag
 
 logger = logging.getLogger(__name__)
 
+GITHUB_BLOG_COMMAND = "github-blog"
+
 
 def _main(
-    url: str, save_path: str | Path, *, save_as_title_list: bool
+    url: str,
+    save_path: str | Path,
+    *,
+    save_as_title_list: bool,
+    days: int | None = None,
 ) -> None:
     fetcher = get_fetcher(url)
-    title_tags = fetcher(url)
+    fetcher_kwargs = {} if days is None else {"days": days}
+    title_tags = fetcher(url, **fetcher_kwargs)
     if save_as_title_list:
         contents = _as_bullet_list(
             title_tag["title"] for title_tag in title_tags
@@ -61,6 +75,9 @@ def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
     Example:
         python -m recent_state_summarizer.fetch \\
           https://awesome.hatenablog.com/archive/2023 articles.jsonl
+
+    The `{GITHUB_BLOG_COMMAND}` sub-command fetches the GitHub Changelog
+    without specifying its feed URL. See `{GITHUB_BLOG_COMMAND} --help`.
     """
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -75,7 +92,57 @@ def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
         default=False,
         help="Save as title-only bullet list instead of JSON Lines",
     )
+    parser.set_defaults(days=None)
     return parser
+
+
+def build_github_blog_parser(
+    add_help: bool = True,
+) -> argparse.ArgumentParser:
+    help_message = f"""
+    Retrieve the titles and URLs of the GitHub Changelog entries published
+    within the recent days, without specifying the feed URL
+    ({GITHUB_BLOG_FEED_URL}).
+
+    Example:
+        python -m recent_state_summarizer.fetch \\
+          {GITHUB_BLOG_COMMAND} articles.jsonl --days 45
+    """
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=textwrap.dedent(help_message),
+        add_help=add_help,
+    )
+    parser.add_argument(
+        "source",
+        choices=[GITHUB_BLOG_COMMAND],
+        help="Fetch the GitHub Changelog feed",
+    )
+    parser.add_argument("save_path", help="Local file path")
+    parser.add_argument(
+        "--as-title-list",
+        action="store_true",
+        default=False,
+        help="Save as title-only bullet list instead of JSON Lines",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=RECENT_DAYS,
+        help="Number of recent days to fetch entries from "
+        f"(default: {RECENT_DAYS})",
+    )
+    parser.set_defaults(url=GITHUB_BLOG_FEED_URL)
+    return parser
+
+
+ParserBuilder = Callable[..., argparse.ArgumentParser]
+
+
+def select_parser_builder(fetch_argv: list[str]) -> ParserBuilder:
+    if fetch_argv[:1] == [GITHUB_BLOG_COMMAND]:
+        return build_github_blog_parser
+    return build_parser
 
 
 def configure_logging() -> None:
@@ -85,7 +152,13 @@ def configure_logging() -> None:
 
 def cli():
     configure_logging()
-    parser = build_parser()
-    args = parser.parse_args()
+    argv = sys.argv[1:]
+    parser = select_parser_builder(argv)()
+    args = parser.parse_args(argv)
 
-    _main(args.url, args.save_path, save_as_title_list=args.as_title_list)
+    _main(
+        args.url,
+        args.save_path,
+        save_as_title_list=args.as_title_list,
+        days=args.days,
+    )

--- a/recent_state_summarizer/fetch/github_changelog.py
+++ b/recent_state_summarizer/fetch/github_changelog.py
@@ -12,6 +12,7 @@ from recent_state_summarizer.fetch.types import TitleTag
 logger = logging.getLogger(__name__)
 
 RECENT_DAYS = 30
+FEED_URL = "https://github.blog/changelog/feed/"
 
 
 def _match_github_changelog(url: str) -> bool:
@@ -22,8 +23,8 @@ def _match_github_changelog(url: str) -> bool:
     )
 
 
-def _recent_cutoff() -> datetime:
-    return datetime.now(timezone.utc) - timedelta(days=RECENT_DAYS)
+def _recent_cutoff(days: int = RECENT_DAYS) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=days)
 
 
 def _published_at(entry) -> datetime:
@@ -31,7 +32,9 @@ def _published_at(entry) -> datetime:
 
 
 @register_fetcher(name="GitHub Changelog", matcher=_match_github_changelog)
-def fetch_github_changelog(url: str) -> Generator[TitleTag, None, None]:
+def fetch_github_changelog(
+    url: str, *, days: int = RECENT_DAYS
+) -> Generator[TitleTag, None, None]:
     """Fetch changelog entries published within the recent days.
 
     The feed returns 10 entries per page and ignores per-page size
@@ -43,11 +46,12 @@ def fetch_github_changelog(url: str) -> Generator[TitleTag, None, None]:
 
     Args:
         url: GitHub Changelog feed URL (https://github.blog/changelog/feed/)
+        days: Number of recent days to fetch entries from
 
     Yields:
         TitleTag dictionaries containing title and url
     """
-    cutoff = _recent_cutoff()
+    cutoff = _recent_cutoff(days)
 
     page = 1
     while True:

--- a/recent_state_summarizer/fetch/registry.py
+++ b/recent_state_summarizer/fetch/registry.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from recent_state_summarizer.fetch.types import TitleTag
 
-Fetcher = Callable[[str], Generator["TitleTag", None, None]]
+Fetcher = Callable[..., Generator["TitleTag", None, None]]
 URLMatcher = Callable[[str], bool]
 
 _registry: list[tuple[str, URLMatcher, Fetcher]] = []

--- a/tests/fetch/test_core.py
+++ b/tests/fetch/test_core.py
@@ -5,6 +5,10 @@ import pytest
 from recent_state_summarizer.fetch.adventar import fetch_adventar_calendar
 from recent_state_summarizer.fetch.cli import cli
 from recent_state_summarizer.fetch.github_changelog import (
+    FEED_URL as GITHUB_BLOG_FEED_URL,
+)
+from recent_state_summarizer.fetch.github_changelog import (
+    RECENT_DAYS,
     fetch_github_changelog,
 )
 from recent_state_summarizer.fetch.hatena_blog import _fetch_titles
@@ -39,7 +43,10 @@ class TestCli:
         cli()
 
         fetch_main.assert_called_once_with(
-            "https://example.com", "output.jsonl", save_as_title_list=False
+            "https://example.com",
+            "output.jsonl",
+            save_as_title_list=False,
+            days=None,
         )
 
     def test_as_title_list(self, fetch_main, monkeypatch):
@@ -56,7 +63,50 @@ class TestCli:
         cli()
 
         fetch_main.assert_called_once_with(
-            "https://example.com", "output.txt", save_as_title_list=True
+            "https://example.com",
+            "output.txt",
+            save_as_title_list=True,
+            days=None,
+        )
+
+    def test_github_blog_sub_command(self, fetch_main, monkeypatch):
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "recent_state_summarizer.fetch",
+                "github-blog",
+                "output.jsonl",
+            ],
+        )
+
+        cli()
+
+        fetch_main.assert_called_once_with(
+            GITHUB_BLOG_FEED_URL,
+            "output.jsonl",
+            save_as_title_list=False,
+            days=RECENT_DAYS,
+        )
+
+    def test_github_blog_sub_command_days(self, fetch_main, monkeypatch):
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "recent_state_summarizer.fetch",
+                "github-blog",
+                "output.jsonl",
+                "--days",
+                "45",
+            ],
+        )
+
+        cli()
+
+        fetch_main.assert_called_once_with(
+            GITHUB_BLOG_FEED_URL,
+            "output.jsonl",
+            save_as_title_list=False,
+            days=45,
         )
 
 

--- a/tests/fetch/test_github_changelog.py
+++ b/tests/fetch/test_github_changelog.py
@@ -61,7 +61,23 @@ def mock_feed_page_not_found(page):
 
 @pytest.fixture
 def fixed_cutoff(monkeypatch):
-    monkeypatch.setattr(github_changelog, "_recent_cutoff", lambda: CUTOFF)
+    monkeypatch.setattr(
+        github_changelog,
+        "_recent_cutoff",
+        lambda days=github_changelog.RECENT_DAYS: CUTOFF,
+    )
+
+
+@pytest.fixture
+def recorded_cutoff_days(monkeypatch):
+    passed_days = []
+
+    def record(days=github_changelog.RECENT_DAYS):
+        passed_days.append(days)
+        return CUTOFF
+
+    monkeypatch.setattr(github_changelog, "_recent_cutoff", record)
+    return passed_days
 
 
 class TestGitHubChangelog:
@@ -252,3 +268,19 @@ class TestGitHubChangelog:
         assert [title_tag["title"] for title_tag in result] == [
             "リダイレクト先の記事"
         ]
+
+    @respx.mock
+    def test_default_days(self, recorded_cutoff_days):
+        mock_feed_page_not_found(1)
+
+        list(fetch_github_changelog(FEED_URL))
+
+        assert recorded_cutoff_days == [github_changelog.RECENT_DAYS]
+
+    @respx.mock
+    def test_days_argument(self, recorded_cutoff_days):
+        mock_feed_page_not_found(1)
+
+        list(fetch_github_changelog(FEED_URL, days=45))
+
+        assert recorded_cutoff_days == [45]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,12 @@ import responses
 import respx
 
 from recent_state_summarizer.__main__ import main, normalize_argv
+from recent_state_summarizer.fetch.github_changelog import (
+    FEED_URL as GITHUB_BLOG_FEED_URL,
+)
+from recent_state_summarizer.fetch.github_changelog import (
+    RECENT_DAYS,
+)
 from recent_state_summarizer.fetch.registry import get_registered_names
 
 
@@ -103,7 +109,52 @@ def test_fetch_subcommand(fetch_main, monkeypatch):
     main()
 
     fetch_main.assert_called_once_with(
-        "https://example.com", "articles.jsonl", save_as_title_list=False
+        "https://example.com",
+        "articles.jsonl",
+        save_as_title_list=False,
+        days=None,
+    )
+
+
+@patch("recent_state_summarizer.__main__.fetch_main")
+def test_fetch_github_blog_sub_command(fetch_main, monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        ["omae-douyo", "fetch", "github-blog", "articles.jsonl"],
+    )
+
+    main()
+
+    fetch_main.assert_called_once_with(
+        GITHUB_BLOG_FEED_URL,
+        "articles.jsonl",
+        save_as_title_list=False,
+        days=RECENT_DAYS,
+    )
+
+
+@patch("recent_state_summarizer.__main__.fetch_main")
+def test_fetch_github_blog_sub_command_days(fetch_main, monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "omae-douyo",
+            "fetch",
+            "github-blog",
+            "titles.txt",
+            "--days",
+            "45",
+            "--as-title-list",
+        ],
+    )
+
+    main()
+
+    fetch_main.assert_called_once_with(
+        GITHUB_BLOG_FEED_URL,
+        "titles.txt",
+        save_as_title_list=True,
+        days=45,
     )
 
 
@@ -180,3 +231,26 @@ def test_fetch_help_includes_fetcher(capsys, monkeypatch, fetcher_name):
     assert (
         fetcher_name in help_output
     ), f"'{fetcher_name}' not found in help message"
+
+
+def test_fetch_help_hides_days_option(capsys, monkeypatch):
+    monkeypatch.setattr("sys.argv", ["omae-douyo", "fetch", "--help"])
+
+    with pytest.raises(SystemExit):
+        main()
+
+    captured = capsys.readouterr()
+    assert "--days" not in captured.out
+    assert "github-blog" in captured.out
+
+
+def test_fetch_github_blog_help_shows_days_option(capsys, monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv", ["omae-douyo", "fetch", "github-blog", "--help"]
+    )
+
+    with pytest.raises(SystemExit):
+        main()
+
+    captured = capsys.readouterr()
+    assert "--days" in captured.out


### PR DESCRIPTION
## 概要

`omae-douyo fetch` に `github-blog` サブコマンドを追加し、GitHub Changelog のフィード URL (`https://github.blog/changelog/feed/`) を省略して取得できるようにしました。あわせて、取得対象の期間をサブコマンド側でのみ `--days` で変更できるようにしています。

```console
# URL 指定なしで取得
$ omae-douyo fetch github-blog articles.jsonl

# 取得期間を変更（デフォルトは 30 日）
$ omae-douyo fetch github-blog articles.jsonl --days 45

# 既存の URL 指定形式はそのまま
$ omae-douyo fetch https://nikkie-ftnext.hatenablog.com/archive/2023/4 articles.jsonl
```

`python -m recent_state_summarizer.fetch github-blog articles.jsonl --days 45` も同様に動きます。

## 設計

argparse は「位置引数 `url`」とサブパーサを同一パーサに共存させられません。そこで `fetch` の直後の引数を見て**パース前に**パーサを選ぶ方式にしました（`fetch/cli.py:select_parser_builder()`）。

これにより:

- `omae-douyo fetch <URL> <save_path>` は従来どおり（`fetch url ...` のような形にはしていません）
- `--days` は `omae-douyo fetch github-blog -h` にのみ現れ、`omae-douyo fetch -h` には出ません
- `normalize_argv()` は変更なし（`fetch` は既知サブコマンドとしてそのまま通過）

`github-blog` 用パーサは `set_defaults(url=FEED_URL)` でフィード URL を供給するため、`url` 位置引数を持たずに `args.url` が埋まります（`parents=` は `set_defaults()` の値も引き継ぎます）。

## 変更点

- `fetch/github_changelog.py`: `FEED_URL` 定数を追加。`fetch_github_changelog(url, *, days=RECENT_DAYS)` と `_recent_cutoff(days)` に期間を引数化（`RECENT_DAYS = 30` はデフォルト値として維持）
- `fetch/cli.py`: `build_github_blog_parser()` / `select_parser_builder()` を追加。`_main()` に `days` を追加し、`None` でないときだけ fetcher にキーワード引数として渡すので他の fetcher のシグネチャは無変更
- `__main__.py`: `build_parser(argv)` が argv からテンプレートを選ぶように変更。`fetch_cli()` が `days` を渡す
- `fetch/registry.py`: `Fetcher` 型エイリアスを `Callable[..., ...]` に緩和
- `README.md` / `CLAUDE.md`: 使い方と設計理由を追記（`build_fetch_parser()` の所在が `fetch/__init__.py` となっていた既存の記述も `fetch/cli.py` に修正）

## テスト

`python -m pytest` — 69 passed

追加したテスト:

- `omae-douyo fetch github-blog <path>` がフィード URL と `days=30` で `_main` を呼ぶこと、`--days 45` / `--as-title-list` が反映されること
- `python -m recent_state_summarizer.fetch github-blog` 経由でも同様であること
- `omae-douyo fetch -h` に `--days` が出ず、`omae-douyo fetch github-blog -h` には出ること
- `fetch_github_changelog(url, days=45)` がカットオフ計算に `45` を渡すこと

実際のフィードに対しても動作確認済み（`--days 7` は 3 ページ目で停止、デフォルト 30 日は 9 ページまで走査）。

## 対象外

要約まで行う `run` 側（`omae-douyo github-blog`）は今回のスコープ外です。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwCuGRuwFhmQx34Ghe7g72)_